### PR TITLE
Fix Incorrect offset for reading 1 byte file

### DIFF
--- a/src/main/java/io/cloudonix/vertx/javaio/WriteToInputStream.java
+++ b/src/main/java/io/cloudonix/vertx/javaio/WriteToInputStream.java
@@ -203,7 +203,7 @@ public class WriteToInputStream extends InputStream implements WriteStream<Buffe
 		if (val < 0)
 			return val;
 		b[off] = (byte) (val & 0xFF);
-		return 1 + read(b, off + 1, len - 1);
+		return 1 + Math.max(0, read(b, off + 1, len - 1));
 	}
 
 	@Override


### PR DESCRIPTION
This causes the only byte in the file to be lost. For this issue https://github.com/cloudonix/vertx-java.io/issues/4